### PR TITLE
Changes on Linux templates and Azure resource naming

### DIFF
--- a/Bicep/add-lnx-compute-nodes.bicep
+++ b/Bicep/add-lnx-compute-nodes.bicep
@@ -14,7 +14,7 @@ param computeNodeNameStartIndex int = 0
 param computeNodeNumber int = 10
 
 @description('The Linux VM image of the compute nodes')
-param computeNodeImage LinuxComputeNodeImage = 'CentOS_7.9'
+param computeNodeImage LinuxComputeNodeImage = 'Ubuntu_24.04'
 
 @description('Specify only when \'CustomImage\' selected for computeNodeImage. The resource Id of the compute node image, it can be a managed VM image in your own subscription (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/images/&lt;ImageName&gt;) or a shared VM image from Azure Shared Image Gallery (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/galleries/&lt;GalleryName&gt;/images/&lt;ImageName&gt;/versions/&lt;ImageVersion&gt;).')
 param computeNodeImageResourceId string = '/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xxx'

--- a/Bicep/add-lnx-compute-nodes.bicep
+++ b/Bicep/add-lnx-compute-nodes.bicep
@@ -83,7 +83,7 @@ param dnsServer string = ''
 
 @secure()
 @description('The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN\'s request headers to Linux nodes.')
-param authenticationKey string = ''
+param authenticationKey string
 
 @description('Optional, specify the resource ID of the user assigned identity to associate with the virtual machines in the form: /subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.ManagedIdentity/userAssignedIdentities/&lt;identityName&gt;')
 param userAssignedIdentity string = ''

--- a/Bicep/new-1hn-lnxcn-existing-ad.bicep
+++ b/Bicep/new-1hn-lnxcn-existing-ad.bicep
@@ -36,7 +36,7 @@ param headNodeOsDiskType DiskType = 'Premium_SSD'
 param headNodeVMSize string = 'Standard_DS4_v2'
 
 @description('The Linux VM image of the compute nodes')
-param computeNodeImage LinuxComputeNodeImage = 'CentOS_7.9'
+param computeNodeImage LinuxComputeNodeImage = 'Ubuntu_24.04'
 
 @description('Specify only when \'CustomImage\' selected for computeNodeImage. The resource Id of the compute node image, it can be a managed VM image in your own subscription (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/images/&lt;ImageName&gt;) or a shared VM image from Azure Shared Image Gallery (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/galleries/&lt;GalleryName&gt;/images/&lt;ImageName&gt;/versions/&lt;ImageVersion&gt;).')
 param computeNodeImageResourceId string = '/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xxx'

--- a/Bicep/new-1hn-lnxcn-existing-ad.bicep
+++ b/Bicep/new-1hn-lnxcn-existing-ad.bicep
@@ -115,7 +115,7 @@ param autoInstallInfiniBandDriver YesOrNo = 'Yes'
 
 @secure()
 @description('The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN\'s request headers to Linux nodes.')
-param authenticationKey string = ''
+param authenticationKey string
 
 @description('Monitor the HPC Pack cluster in Azure Monitor.')
 param enableAzureMonitor YesOrNo = 'Yes'

--- a/Bicep/new-1hn-lnxcn-no-ad.bicep
+++ b/Bicep/new-1hn-lnxcn-no-ad.bicep
@@ -21,7 +21,7 @@ param headNodeOsDiskType DiskType = 'Premium_SSD'
 param headNodeVMSize string = 'Standard_DS4_v2'
 
 @description('The Linux VM image of the compute nodes')
-param computeNodeImage LinuxComputeNodeImage = 'CentOS_7.9'
+param computeNodeImage LinuxComputeNodeImage = 'Ubuntu_24.04'
 
 @description('Specify only when \'CustomImage\' selected for computeNodeImage. The resource Id of the compute node image, it can be a managed VM image in your own subscription (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/images/&lt;ImageName&gt;) or a shared VM image from Azure Shared Image Gallery (/subscriptions/&lt;SubscriptionId&gt;/resourceGroups/&lt;ResourceGroupName&gt;/providers/Microsoft.Compute/galleries/&lt;GalleryName&gt;/images/&lt;ImageName&gt;/versions/&lt;ImageVersion&gt;).')
 param computeNodeImageResourceId string = '/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xxx'

--- a/Bicep/new-1hn-lnxcn-no-ad.bicep
+++ b/Bicep/new-1hn-lnxcn-no-ad.bicep
@@ -99,7 +99,7 @@ param autoInstallInfiniBandDriver YesOrNo = 'Yes'
 
 @secure()
 @description('The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN\'s request headers to Linux nodes.')
-param authenticationKey string = ''
+param authenticationKey string
 
 @description('Monitor the HPC Pack cluster in Azure Monitor.')
 param enableAzureMonitor YesOrNo = 'Yes'

--- a/Bicep/shared/azure-monitor.bicep
+++ b/Bicep/shared/azure-monitor.bicep
@@ -3,7 +3,7 @@ import { AzureMonitorLogSettings, AzureMonitorAgentSettings } from 'types-and-va
 param name string = 'azuremonitor'
 param location string = resourceGroup().location
 
-var uniqStr = uniqueString(resourceGroup().id)
+var uniqStr = take(uniqueString(resourceGroup().id), 8)
 var prefix = '${name}-${uniqStr}-'
 var workSpaceName = '${prefix}workspace'
 
@@ -11,7 +11,6 @@ resource workSpace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: workSpaceName
   location: location
 }
-
 
 module logIngestion 'log-ingestion.bicep' = {
   name: 'logIngestion'

--- a/Bicep/shared/log-ingestion.bicep
+++ b/Bicep/shared/log-ingestion.bicep
@@ -7,7 +7,7 @@ resource workSpace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existin
 }
 
 module customTable 'custom-la-table.bicep' = {
-  name: '${prefix}logIngestionCustomTable'
+  name: '${prefix}LogTable'
   params: {
     prefix: prefix
     workSpaceName: workSpace.name
@@ -15,19 +15,19 @@ module customTable 'custom-la-table.bicep' = {
 }
 
 resource dce 'Microsoft.Insights/dataCollectionEndpoints@2023-03-11' = {
-  name: '${prefix}logIngestionDce'
+  name: '${prefix}LogDce'
   location: location
   properties: {
   }
 }
 
 resource userMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: '${prefix}logIngestionUserMi'
+  name: '${prefix}LogUserMi'
   location: location
 }
 
 module dcr 'dcr-log-ingestion.bicep' = {
-  name: '${prefix}logIngestionDcr'
+  name: '${prefix}LogDcr'
   params: {
     dataCollectionRuleName: '${prefix}dcrLogIngestionApi'
     workspaceResId: workSpace.id

--- a/GeneratedTemplates/add-lnx-compute-nodes.json
+++ b/GeneratedTemplates/add-lnx-compute-nodes.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "7892512261582841923"
+      "templateHash": "2495314497880629987"
     }
   },
   "definitions": {
@@ -191,7 +191,7 @@
     },
     "computeNodeImage": {
       "$ref": "#/definitions/LinuxComputeNodeImage",
-      "defaultValue": "CentOS_7.9",
+      "defaultValue": "Ubuntu_24.04",
       "metadata": {
         "description": "The Linux VM image of the compute nodes"
       }
@@ -337,7 +337,6 @@
     },
     "authenticationKey": {
       "type": "securestring",
-      "defaultValue": "",
       "metadata": {
         "description": "The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN's request headers to Linux nodes."
       }

--- a/GeneratedTemplates/new-1hn-lnxcn-existing-ad.json
+++ b/GeneratedTemplates/new-1hn-lnxcn-existing-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "80426459613202796"
+      "templateHash": "2064860644886088506"
     }
   },
   "definitions": {
@@ -316,7 +316,7 @@
     },
     "computeNodeImage": {
       "$ref": "#/definitions/LinuxComputeNodeImage",
-      "defaultValue": "CentOS_7.9",
+      "defaultValue": "Ubuntu_24.04",
       "metadata": {
         "description": "The Linux VM image of the compute nodes"
       }
@@ -479,7 +479,6 @@
     },
     "authenticationKey": {
       "type": "securestring",
-      "defaultValue": "",
       "metadata": {
         "description": "The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN's request headers to Linux nodes."
       }
@@ -1231,7 +1230,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -1288,7 +1287,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -1329,7 +1328,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -1348,20 +1347,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1452,7 +1451,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1466,11 +1465,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1616,32 +1615,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-1hn-lnxcn-no-ad.json
+++ b/GeneratedTemplates/new-1hn-lnxcn-no-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "17952184569300743410"
+      "templateHash": "2890332625014462513"
     }
   },
   "definitions": {
@@ -285,7 +285,7 @@
     },
     "computeNodeImage": {
       "$ref": "#/definitions/LinuxComputeNodeImage",
-      "defaultValue": "CentOS_7.9",
+      "defaultValue": "Ubuntu_24.04",
       "metadata": {
         "description": "The Linux VM image of the compute nodes"
       }
@@ -448,7 +448,6 @@
     },
     "authenticationKey": {
       "type": "securestring",
-      "defaultValue": "",
       "metadata": {
         "description": "The AuthenticationKey for Linux nodes. Head nodes must have ClusterAuthenticationKey set in their registry so that it is included in HN's request headers to Linux nodes."
       }
@@ -1197,7 +1196,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -1254,7 +1253,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -1295,7 +1294,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -1314,20 +1313,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1418,7 +1417,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1432,11 +1431,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1582,32 +1581,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-1hn-wincn-ad.json
+++ b/GeneratedTemplates/new-1hn-wincn-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "3112904429081965949"
+      "templateHash": "11069040262300117503"
     }
   },
   "definitions": {
@@ -797,7 +797,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -854,7 +854,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -895,7 +895,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -914,20 +914,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1018,7 +1018,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1032,11 +1032,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1182,32 +1182,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-1hn-wincn-existing-ad.json
+++ b/GeneratedTemplates/new-1hn-wincn-existing-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "13647636282283162516"
+      "templateHash": "13465599852101489181"
     }
   },
   "definitions": {
@@ -814,7 +814,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -871,7 +871,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -912,7 +912,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -931,20 +931,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1035,7 +1035,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1049,11 +1049,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1199,32 +1199,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-1hn-wincn-no-ad.json
+++ b/GeneratedTemplates/new-1hn-wincn-no-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "1543517401014276148"
+      "templateHash": "12367922543025088442"
     }
   },
   "definitions": {
@@ -782,7 +782,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -839,7 +839,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -880,7 +880,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -899,20 +899,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1003,7 +1003,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1017,11 +1017,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1167,32 +1167,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-2hn-wincn-ad.json
+++ b/GeneratedTemplates/new-2hn-wincn-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "136491980954180682"
+      "templateHash": "10651908153617015415"
     }
   },
   "definitions": {
@@ -896,7 +896,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -953,7 +953,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -994,7 +994,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -1013,20 +1013,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1117,7 +1117,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1131,11 +1131,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1281,32 +1281,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-2hn-wincn-existing-ad-azuresql.json
+++ b/GeneratedTemplates/new-2hn-wincn-existing-ad-azuresql.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "2047081490286320691"
+      "templateHash": "1793973276599448054"
     }
   },
   "definitions": {
@@ -1040,7 +1040,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -1097,7 +1097,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -1138,7 +1138,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -1157,20 +1157,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1261,7 +1261,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1275,11 +1275,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1425,32 +1425,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }

--- a/GeneratedTemplates/new-2hn-wincn-existing-ad.json
+++ b/GeneratedTemplates/new-2hn-wincn-existing-ad.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "4920304606575031627"
+      "templateHash": "14544174022455493079"
     }
   },
   "definitions": {
@@ -906,7 +906,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "933294187094482452"
+              "templateHash": "15733758896132684114"
             }
           },
           "definitions": {
@@ -963,7 +963,7 @@
             }
           },
           "variables": {
-            "uniqStr": "[uniqueString(resourceGroup().id)]",
+            "uniqStr": "[take(uniqueString(resourceGroup().id), 8)]",
             "prefix": "[format('{0}-{1}-', parameters('name'), variables('uniqStr'))]",
             "workSpaceName": "[format('{0}workspace', variables('prefix'))]"
           },
@@ -1004,7 +1004,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "2774853078011716515"
+                      "templateHash": "7920368250566220215"
                     }
                   },
                   "parameters": {
@@ -1023,20 +1023,20 @@
                     {
                       "type": "Microsoft.Insights/dataCollectionEndpoints",
                       "apiVersion": "2023-03-11",
-                      "name": "[format('{0}logIngestionDce', parameters('prefix'))]",
+                      "name": "[format('{0}LogDce', parameters('prefix'))]",
                       "location": "[parameters('location')]",
                       "properties": {}
                     },
                     {
                       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
                       "apiVersion": "2023-01-31",
-                      "name": "[format('{0}logIngestionUserMi', parameters('prefix'))]",
+                      "name": "[format('{0}LogUserMi', parameters('prefix'))]",
                       "location": "[parameters('location')]"
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionCustomTable', parameters('prefix'))]",
+                      "name": "[format('{0}LogTable', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1127,7 +1127,7 @@
                     {
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}logIngestionDcr', parameters('prefix'))]",
+                      "name": "[format('{0}LogDcr', parameters('prefix'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -1141,11 +1141,11 @@
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workSpaceName'))]"
                           },
                           "dataCollectionEndpointId": {
-                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]"
+                            "value": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]"
                           },
                           "userMiPrincipalIds": {
                             "value": [
-                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').principalId]"
+                              "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').principalId]"
                             ]
                           }
                         },
@@ -1291,32 +1291,32 @@
                         }
                       },
                       "dependsOn": [
-                        "[resourceId('Microsoft.Resources/deployments', format('{0}logIngestionCustomTable', parameters('prefix')))]",
-                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix')))]",
-                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                        "[resourceId('Microsoft.Resources/deployments', format('{0}LogTable', parameters('prefix')))]",
+                        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix')))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                       ]
                     }
                   ],
                   "outputs": {
                     "logsIngestionEndpoint": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}logIngestionDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
+                      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', format('{0}LogDce', parameters('prefix'))), '2023-03-11').logsIngestion.endpoint]"
                     },
                     "dcrRunId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrRunId.value]"
                     },
                     "dcrStreamName": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}logIngestionDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}LogDcr', parameters('prefix'))), '2022-09-01').outputs.dcrStreamName.value]"
                     },
                     "userMiResId": {
                       "type": "string",
-                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix')))]"
+                      "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix')))]"
                     },
                     "userMiClientId": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}logIngestionUserMi', parameters('prefix'))), '2023-01-31').clientId]"
+                      "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}LogUserMi', parameters('prefix'))), '2023-01-31').clientId]"
                     }
                   }
                 }


### PR DESCRIPTION
1. Make shorter names for some Azure resources to pass Azure check
2. Make param authenticationKey required for linux templates.
3. Change default compute node image to Ubuntu from CentOS